### PR TITLE
Dev1

### DIFF
--- a/.github/workflows/repository_dispatch.yml
+++ b/.github/workflows/repository_dispatch.yml
@@ -15,6 +15,6 @@ jobs:
       - name: Dispara 'repository_dispatch' no books
         uses: peter-evans/repository-dispatch@v3
         with:
-          repository: czargab18/books
+          repository: czargab18/estatistica
           token: ${{ secrets.GITHUB_TOKEN }}
           event-type: atualiza-books

--- a/.github/workflows/repository_dispatch.yml
+++ b/.github/workflows/repository_dispatch.yml
@@ -15,6 +15,6 @@ jobs:
       - name: Dispara 'repository_dispatch' no books
         uses: peter-evans/repository-dispatch@v3
         with:
-          repository: czargab18/estatistica
+          repository: ${{ github.repository_owner}}/estatistica
           token: ${{ secrets.GITHUB_TOKEN }}
           event-type: atualiza-books


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow configuration, changing the target repository for the `repository_dispatch` event to use a dynamic repository owner and a new repository name. 

- Updated the `repository_dispatch` action in `.github/workflows/repository_dispatch.yml` to dispatch to `${{ github.repository_owner }}/estatistica` instead of the hardcoded `czargab18/books` repository.